### PR TITLE
Update BuildTools.cs

### DIFF
--- a/Assets/BuildTools/Editor/BuildTools.cs
+++ b/Assets/BuildTools/Editor/BuildTools.cs
@@ -158,6 +158,12 @@ public class BuildTools : EditorWindow
         {
             string apkName = PlayerSettings.productName + ".apk";
             options.locationPathName = System.IO.Path.Combine("Builds", target.ToString(), apkName);
+        }else if (target == BuildTarget.StandaloneWindows64)
+        {
+            options.locationPathName = System.IO.Path.Combine("Builds", target.ToString(), PlayerSettings.productName+".exe");
+        }else if (target == BuildTarget.StandaloneLinux64)
+        {
+            options.locationPathName = System.IO.Path.Combine("Builds", target.ToString(), PlayerSettings.productName+".x86_64");
         }
         else
             options.locationPathName = System.IO.Path.Combine("Builds", target.ToString(), PlayerSettings.productName);


### PR DESCRIPTION
Small addition of lines to the code, to fix the lack of extensions(.exe and .x86_64) on windows(64 bits) and linux builds (Sorry for deleting the previous one, I'm a newbie on github related things ^^')