### PR TITLE
Update BuildTools.cs

### DIFF
--- a/Assets/BuildTools/Editor/BuildTools.cs
+++ b/Assets/BuildTools/Editor/BuildTools.cs
@@ -154,6 +154,7 @@ public class BuildTools : EditorWindow
         options.targetGroup = GetTargetGroupForTarget(target);
 
         // set the location path name
+        EditorUserBuildSettings.SwitchActiveBuildTarget(GetTargetGroupForTarget(target), target);
         if (target == BuildTarget.Android)
         {
             string apkName = PlayerSettings.productName + ".apk";


### PR DESCRIPTION
Fix for android build not working if android is not selected as build target. This sadly doesn't fix linux builds with IL2CPP not working